### PR TITLE
Add release-plan.yaml

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -1,0 +1,42 @@
+# CAMARA Release Plan
+# This file declares release intentions for this repository.
+# It replaces manual wiki tracking with automated tooling.
+#
+# Workflow: Update this file → CI validates → Trigger release when ready
+# Docs: https://github.com/camaraproject/ReleaseManagement
+
+repository:
+  # How this repository participates in CAMARA releases
+  # Options: none | independent | meta-release
+  release_track: independent
+
+  # Uncomment and set when planning a meta-release participation:
+  # meta_release: Fall26
+
+  # Release tag — first release for a repository is r1.1
+  # - New release cycle (increment first number, reset second to 1)
+  # - Progression in same cycle (increment second number)
+  target_release_tag: r1.1
+
+  # Release type being prepared (must be set before release can be triggered)
+  # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
+  target_release_type: none
+
+# Dependencies on Commonalities and ICM releases
+# Update per ReleaseManagement requirements for each release cycle
+dependencies:
+  commonalities_release: r3.4
+  identity_consent_management_release: r3.3
+
+# APIs in this repository
+# Update with your actual API(s) when ready:
+# - api_name: kebab-case identifier (will be filename in code/API_definitions/)
+# - target_api_status: draft (no file yet) | alpha (file exists) | rc | public
+apis:
+  - api_name: example-api
+    target_api_version: 0.1.0
+    target_api_status: draft
+    main_contacts:
+      - jpengar
+      - AxelNennker
+      - sebdewet


### PR DESCRIPTION
## Summary
- Add initial release-plan.yaml for this repository
- Tests validation workflow from hdamker/tooling@release-plan-validation

## Test plan
- [x] Verify release-plan.yaml validation runs
- [x] Verify separate check status appears in PR UI
- [x] Verify MegaLinter runs after validation