### PR TITLE
Configure r1.1 pre-release-rc

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -33,9 +33,9 @@ dependencies:
 # - api_name: kebab-case identifier (will be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha (file exists) | rc | public
 apis:
-  - api_name: example-api
+  - api_name: quality-on-demand
     target_api_version: 0.1.0
-    target_api_status: draft
+    target_api_status: rc
     main_contacts:
       - jpengar
       - AxelNennker


### PR DESCRIPTION
Configure release-plan.yaml for r1.1 pre-release-rc:
- target_release_type: none → pre-release-rc
- api_name: example-api → quality-on-demand
- target_api_status: draft → rc

WP23 E2E testing — first release setup.