### PR TITLE
Update commonalities dependency to r3.5

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
+  commonalities_release: r3.5
   identity_consent_management_release: r3.3
 
 # APIs in this repository


### PR DESCRIPTION
Drift test: change commonalities_release from r3.4 to r3.5 while r1.2 snapshot is active.